### PR TITLE
Widget pluralization

### DIFF
--- a/widget/models.py
+++ b/widget/models.py
@@ -148,7 +148,7 @@ class Widget(Orderable, Ownable):
 
     class Meta:
         verbose_name = _("Widget")
-        verbose_name_plural = _("Widget's")
+        verbose_name_plural = _("Widgets")
         ordering = ("display_title",) 
 
 


### PR DESCRIPTION
Corrects the pluralization of "widget". Should be "widgets" instead of "widget's".
